### PR TITLE
[b] Fix null owner parsing for some names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suins/toolkit",
-  "version": "1.5.1",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suins/toolkit",
-      "version": "1.5.1",
+      "version": "1.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.33.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Sui Name Service <info@suins.io>",
   "description": "SuiNS TypeScript SDK",
   "license": "Apache-2.0",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "files": [
     "dist",
     "src"

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -13,8 +13,10 @@ export const getOwner = async (
     id: nftId,
     options: { showOwner: true },
   });
+  const owner = getObjectOwner(ownerResponse);
   return (
-    (getObjectOwner(ownerResponse) as { AddressOwner: string })?.AddressOwner ||
+    (owner as { AddressOwner: string })?.AddressOwner ||
+    (owner as { ObjectOwner: string })?.ObjectOwner ||
     null
   );
 };


### PR DESCRIPTION
Fix null owner parsing for some names as the owner is not in `AddressOwner` but in `ObjectOwner`. Take `best.sui` as an example for the bug here. Other names without bugs you could try out are `menion.sui`, `blackpink.sui`, etc. 

Request:
```
{
  "method": "sui_getObject",
  "jsonrpc": "2.0",
  "params": [
    "0x3fd72d18fd99da02c5b1e8f808f23df97fd39e5b19a6befe5c23408d1e3c6627",
    {
      "showOwner": true
    }
  ]
}
```

Response:

```
{
  "data": {
    "objectId": "0x3fd72d18fd99da02c5b1e8f808f23df97fd39e5b19a6befe5c23408d1e3c6627",
    "version": "4054600",
    "digest": "74eM5Khj7nda1MqQyVtg4KbGpSXudNJLhToivRKPv4Da",
    "owner": {
      "ObjectOwner": "0xb6b10d9bb973aa813e76ccc70a8d9cf80c4561735507bd41a1960c4548d865e5"
    }
  }
}
```